### PR TITLE
fix: remove name from the field

### DIFF
--- a/src/bootstrap-show-password.js
+++ b/src/bootstrap-show-password.js
@@ -105,7 +105,7 @@ class Password {
     for (const attr of this.$element[0].attributes) {
       if (
         !attr.specified ||
-        ['id', 'type'].includes(attr.name) ||
+        ['id', 'type', 'name'].includes(attr.name) ||
         attr.name.indexOf('data-') === 0
       ) {
         continue


### PR DESCRIPTION
Adding name field in version 1.3 is disrupting the app since there are two fields with the same name.